### PR TITLE
Set the current item displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ public class MainActivity extends FragmentActivity {
                 .addImage(R.drawable.wallpaper4)
                 .addImage(R.drawable.wallpaper5)
                 .addImage(R.drawable.wallpaper6)
-                .addImage(convertDrawableToBitmap(R.drawable.wallpaper7));
+                .addImage(convertDrawableToBitmap(R.drawable.wallpaper7))
+                .setCurrentItem(2);
     }
 
     private Bitmap convertDrawableToBitmap(int image) {

--- a/app/src/main/java/com/veinhorn/example/MainActivity.java
+++ b/app/src/main/java/com/veinhorn/example/MainActivity.java
@@ -25,7 +25,8 @@ public class MainActivity extends FragmentActivity {
                 .addImage(R.drawable.wallpaper4)
                 .addImage(R.drawable.wallpaper5)
                 .addImage(R.drawable.wallpaper6)
-                .addImage(convertDrawableToBitmap(R.drawable.wallpaper7));
+                .addImage(convertDrawableToBitmap(R.drawable.wallpaper7))
+                .setCurrentItem(2);
     }
 
     private Bitmap convertDrawableToBitmap(int image) {

--- a/library/src/main/java/com/veinhorn/scrollgalleryview/ScrollGalleryView.java
+++ b/library/src/main/java/com/veinhorn/scrollgalleryview/ScrollGalleryView.java
@@ -102,6 +102,16 @@ public class ScrollGalleryView extends LinearLayout {
         return this;
     }
 
+    /**
+     * Set the current item displayed in the view pager.
+     * @param i     a zero-based index
+     * @return
+     */
+    public ScrollGalleryView setCurrentItem(int i) {
+        viewPager.setCurrentItem(i, false);
+        return this;
+    }
+
     public ScrollGalleryView setThumbnailSize(int thumbnailSize) {
         this.thumbnailSize = thumbnailSize;
         return this;


### PR DESCRIPTION
This proves to be useful when a user clicks on an image that belongs to an ordered sequence of images (an album), and one wants to display a gallery with these images, with the selected image displayed initially.