### PR TITLE
Add getCurrentItem method to ScrollGalleryView

### DIFF
--- a/library/src/main/java/com/veinhorn/scrollgalleryview/ScrollGalleryView.java
+++ b/library/src/main/java/com/veinhorn/scrollgalleryview/ScrollGalleryView.java
@@ -146,6 +146,10 @@ public class ScrollGalleryView extends LinearLayout {
         return this;
     }
 
+    public int getCurrentItem() {
+        return viewPager.getCurrentItem();
+    }
+
     public ScrollGalleryView setThumbnailSize(int thumbnailSize) {
         this.thumbnailSize = thumbnailSize;
         return this;


### PR DESCRIPTION
This is the simplest version of the change. I've just added `getCurrentItem()` that exposes the same method from `ViewPager`. 

I just noticed that you've added a `getViewPager()` method where you can get the whole ViewPager object. Maybe this could lead to bad usages from library users, such as changing the adapter and breaking up the whole thing.

Anyway, if you want to include this method in the next version, I think it could be useful :) I wait for the next release to have some issues like #27 or #32 fixed. 

I've also had a look at #43. I think it is related to this code:

    public ScrollGalleryView setCurrentItem(int i) {
        viewPager.setCurrentItem(i, false);
        return this;
    }

I've just discovered that `setCurrentItem` can be called before initializing the ViewPager, so it causes `NullPointerException`. A workaround could be calling `.setCurrentItem` after `.setFragmentManager`. I'll update my comment in #43. 