### PR TITLE
Added possibility to use glide

### DIFF
--- a/library/src/main/java/com/veinhorn/scrollgalleryview/ImageFragment.java
+++ b/library/src/main/java/com/veinhorn/scrollgalleryview/ImageFragment.java
@@ -39,9 +39,6 @@ public class ImageFragment extends Fragment {
         if (savedInstanceState != null) {
             boolean isLocked = savedInstanceState.getBoolean(Constants.IS_LOCKED, false);
             viewPager.setLocked(isLocked);
-            if (savedInstanceState.containsKey(Constants.IMAGE)) {
-                backgroundImage.setImageBitmap((Bitmap) savedInstanceState.getParcelable(Constants.IMAGE));
-            }
             createViewAttacher(savedInstanceState);
         }
 
@@ -71,9 +68,6 @@ public class ImageFragment extends Fragment {
     public void onSaveInstanceState(@NonNull Bundle outState) {
         if (isViewPagerActive()) {
             outState.putBoolean(Constants.IS_LOCKED, viewPager.isLocked());
-        }
-        if (isBackgroundImageActive()) {
-            outState.putParcelable(Constants.IMAGE, ((BitmapDrawable) backgroundImage.getDrawable()).getBitmap());
         }
         outState.putBoolean(Constants.ZOOM, photoViewAttacher != null);
         super.onSaveInstanceState(outState);

--- a/library/src/main/java/com/veinhorn/scrollgalleryview/ScrollGalleryView.java
+++ b/library/src/main/java/com/veinhorn/scrollgalleryview/ScrollGalleryView.java
@@ -54,7 +54,7 @@ public class ScrollGalleryView extends LinearLayout {
     private final OnClickListener thumbnailOnClickListener = new OnClickListener() {
         @Override public void onClick(View v) {
             scroll(v);
-            viewPager.setCurrentItem((int) v.getTag(), true);
+            viewPager.setCurrentItem((int) v.getId(), true);
         }
     };
 
@@ -196,7 +196,7 @@ public class ScrollGalleryView extends LinearLayout {
         ImageView thumbnailView = new ImageView(context);
         thumbnailView.setLayoutParams(lp);
         thumbnailView.setImageBitmap(thumbnail);
-        thumbnailView.setTag(mListOfMedia.size() - 1);
+        thumbnailView.setId(mListOfMedia.size() - 1);
         thumbnailView.setOnClickListener(thumbnailOnClickListener);
         thumbnailView.setScaleType(ImageView.ScaleType.CENTER);
         return thumbnailView;


### PR DESCRIPTION
Glide throws exceptions if you modify the tag of the ImageViews yourself. I've changed the code to set/get ids instead of tags.
Then, onSaveStateInstance was crashing because Glide uses a GlideBitmapDrawable causing a ClassCastException. I've removed those lines in save and restore since they are not needed. I've tested the code using also DefaultImageLoader and it still works without those lines.