### PR TITLE
removed black background

### DIFF
--- a/library/src/main/res/layout/image_fragment.xml
+++ b/library/src/main/res/layout/image_fragment.xml
@@ -8,7 +8,6 @@
         android:id="@+id/backgroundImage"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="#000000"
         android:scaleType="center"
         android:src="@drawable/placeholder_image" />
 </LinearLayout>


### PR DESCRIPTION
The black background set in this fragment overrides the background you could set to ScrollGalleryView as shown in the readme, so I've removed it.