### PR TITLE
#58: app name removed from library resources

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
     package="com.veinhorn.scrollgalleryview">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <application android:allowBackup="true" android:label="@string/app_name">
+    <application android:allowBackup="true" android:label="ScrollGalleryView">
         <activity android:name="com.veinhorn.scrollgalleryview.VideoPlayerActivity" />
     </application>
 

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
     package="com.veinhorn.scrollgalleryview">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <application android:allowBackup="true" android:label="ScrollGalleryView">
+    <application android:allowBackup="true">
         <activity android:name="com.veinhorn.scrollgalleryview.VideoPlayerActivity" />
     </application>
 

--- a/library/src/main/res/values-ru/strings.xml
+++ b/library/src/main/res/values-ru/strings.xml
@@ -1,4 +1,3 @@
 <resources>
-    <string name="app_name">ScrollGalleryView</string>
     <string name="loading">Загрузка…</string>
 </resources>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,4 +1,3 @@
 <resources>
-    <string name="app_name">ScrollGalleryView</string>
     <string name="loading">Loading…</string>
 </resources>


### PR DESCRIPTION
app_name resource string is removed from library resources to avoid clashes with standart app_name string resource for Android projects